### PR TITLE
Add sample Todo API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # codex
+
+Simple Express server with a sample Todo API.
+
+## Usage
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Start the server:
+
+```bash
+npm start
+```
+
+### Todo API
+
+- `GET /todos` - list all todos
+- `POST /todos` - create a todo with JSON body `{ "title": "Buy milk" }`
+- `DELETE /todos/:id` - remove a todo by id

--- a/routes/todos.js
+++ b/routes/todos.js
@@ -1,0 +1,31 @@
+const express = require('express');
+const router = express.Router();
+
+let todos = [];
+let idCounter = 1;
+
+router.get('/', (req, res) => {
+  res.json(todos);
+});
+
+router.post('/', (req, res) => {
+  const { title } = req.body;
+  if (!title) {
+    return res.status(400).json({ error: 'Title is required' });
+  }
+  const todo = { id: idCounter++, title };
+  todos.push(todo);
+  res.status(201).json(todo);
+});
+
+router.delete('/:id', (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  const index = todos.findIndex(t => t.id === id);
+  if (index === -1) {
+    return res.status(404).json({ error: 'Not found' });
+  }
+  const [removed] = todos.splice(index, 1);
+  res.json(removed);
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -1,13 +1,16 @@
 const express = require('express');
+const todosRouter = require('./routes/todos');
 const app = express();
-const PORT = 4000;
+const PORT = process.env.PORT || 4000;
+
+app.use(express.json());
 
 app.get('/', (req, res) => {
   res.send('✅ 서버 살아있음!');
 });
 
+app.use('/todos', todosRouter);
+
 app.listen(PORT, () => {
   console.log(`🚀 서버 실행 중: http://localhost:${PORT}`);
 });
-
-// 강제로 종료되는지 확인용 타이머 제거


### PR DESCRIPTION
## Summary
- add a simple Todo API using an Express router
- update the Express server to mount the new routes
- document usage and endpoints in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683fab122ccc832c94e7ebb1a3a412c2