### PR TITLE
Add persisted Todo API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # codex
+
+Simple Express server with a sample Todo API stored in `data/todos.json`.
+
+## Usage
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Start the server:
+
+```bash
+npm start
+```
+
+### Todo API
+
+- `GET /todos` - list all todos
+  - `completed=true|false` query filters by status
+- `GET /todos/:id` - get a single todo
+- `POST /todos` - create a todo with JSON body `{ "title": "Buy milk" }`
+- `PUT /todos/:id` - update title or `completed` flag
+- `DELETE /todos/:id` - remove a todo by id

--- a/data/todos.json
+++ b/data/todos.json
@@ -1,0 +1,4 @@
+{
+  "idCounter": 1,
+  "todos": []
+}

--- a/routes/todos.js
+++ b/routes/todos.js
@@ -1,0 +1,85 @@
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+
+const router = express.Router();
+
+const DATA_FILE = path.join(__dirname, '..', 'data', 'todos.json');
+
+let todos = [];
+let idCounter = 1;
+
+function loadTodos() {
+  try {
+    const data = JSON.parse(fs.readFileSync(DATA_FILE, 'utf8'));
+    todos = data.todos || [];
+    idCounter = data.idCounter || 1;
+  } catch (err) {
+    todos = [];
+    idCounter = 1;
+  }
+}
+
+function saveTodos() {
+  fs.mkdirSync(path.dirname(DATA_FILE), { recursive: true });
+  fs.writeFileSync(DATA_FILE, JSON.stringify({ todos, idCounter }, null, 2));
+}
+
+loadTodos();
+
+router.get('/', (req, res) => {
+  const { completed } = req.query;
+  let result = todos;
+  if (completed === 'true') {
+    result = todos.filter(t => t.completed);
+  } else if (completed === 'false') {
+    result = todos.filter(t => !t.completed);
+  }
+  res.json(result);
+});
+
+router.get('/:id', (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  const todo = todos.find(t => t.id === id);
+  if (!todo) {
+    return res.status(404).json({ error: 'Not found' });
+  }
+  res.json(todo);
+});
+
+router.post('/', (req, res) => {
+  const { title } = req.body;
+  if (!title) {
+    return res.status(400).json({ error: 'Title is required' });
+  }
+  const todo = { id: idCounter++, title, completed: false };
+  todos.push(todo);
+  saveTodos();
+  res.status(201).json(todo);
+});
+
+router.put('/:id', (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  const todo = todos.find(t => t.id === id);
+  if (!todo) {
+    return res.status(404).json({ error: 'Not found' });
+  }
+  const { title, completed } = req.body;
+  if (title !== undefined) todo.title = title;
+  if (completed !== undefined) todo.completed = Boolean(completed);
+  saveTodos();
+  res.json(todo);
+});
+
+router.delete('/:id', (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  const index = todos.findIndex(t => t.id === id);
+  if (index === -1) {
+    return res.status(404).json({ error: 'Not found' });
+  }
+  const [removed] = todos.splice(index, 1);
+  saveTodos();
+  res.json(removed);
+});
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -1,13 +1,16 @@
 const express = require('express');
+const todosRouter = require('./routes/todos');
 const app = express();
-const PORT = 4000;
+const PORT = process.env.PORT || 4000;
+
+app.use(express.json());
 
 app.get('/', (req, res) => {
   res.send('✅ 서버 살아있음!');
 });
 
+app.use('/todos', todosRouter);
+
 app.listen(PORT, () => {
   console.log(`🚀 서버 실행 중: http://localhost:${PORT}`);
 });
-
-// 강제로 종료되는지 확인용 타이머 제거


### PR DESCRIPTION
## Summary
- persist todos to `data/todos.json`
- support filtering, updating, and retrieving by ID
- document new API features

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683fab122ccc832c94e7ebb1a3a412c2